### PR TITLE
Moved Travis build forward.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: bash
+
+before_install:
+  - wget http://downloads.verapdf.org/rel/verapdf-installer.zip
+  - unzip verapdf-installer.zip
+  - cd verapdf-0.24.2
+  - ./verapdf-install.sh
+  - ./verapdf --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ language: bash
 before_install:
   - wget http://downloads.verapdf.org/rel/verapdf-installer.zip
   - unzip verapdf-installer.zip -d ./vera-installer
-  - cd vera-installer
-  - ./verapdf-install.sh
+  - find ./vera-installer -name "verapdf-install" -type f -exec {} \;
   - ./verapdf --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: bash
 
 before_install:
   - wget http://downloads.verapdf.org/rel/verapdf-installer.zip
-  - unzip verapdf-installer.zip
-  - cd verapdf-0.24.2
+  - unzip verapdf-installer.zip -d ./vera-installer
+  - cd vera-installer
   - ./verapdf-install.sh
   - ./verapdf --version


### PR DESCRIPTION
- removed bash prefix from shell calls;
- forced consistent directory name for installer unpacking; and
- execute installer using the `find` command.

This will still fail as Travis is headless and the installer requires a GUI. Command line installation is possible by using a script generated by the izpack installer.